### PR TITLE
Open syscalls

### DIFF
--- a/hatrace.cabal
+++ b/hatrace.cabal
@@ -71,6 +71,7 @@ test-suite hatrace-test
                      , hatrace
                      , hspec
                      , process
+                     , temporary
                      , text
                      , unix
                      , unliftio

--- a/test/HatraceSpec.hs
+++ b/test/HatraceSpec.hs
@@ -6,7 +6,7 @@
 module HatraceSpec where
 
 import           Control.Monad (when)
-import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
 import qualified Data.ByteString as BS
 import           Data.Conduit


### PR DESCRIPTION
Originally I wanted to use in details `OpenMode` and `OpenFileFlag` from the `unix` package but those don't have `Eq` or even `Show` so only `pathname` gets converted to a better Haskell data type.
Filter for https://github.com/commercialhaskell/stack/issues/4559#issuecomment-476211250 will be based on this branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nh2/hatrace/6)
<!-- Reviewable:end -->
