### PR TITLE
Implement -find-nonatomic-writes filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ It is recommended to file an issue when picking up one of the tasks to coordinat
 * [ ] Support for setting options (for example enabling/disabling tracing into subprocesses, like `strace -f`)
 * [ ] Equivalent to `strace -y` (tracking origin of file descriptors, printing paths)
 * [ ] Equivalent to `strace -c` (keeping counts, summary statistics)
+* [ ] Something similar to `strace -y` but telling which PID is which executable from `/proc/PID/exe`
 * [ ] Extraction of `PTRACE_EVENT` detail information (see section `PTRACE_SETOPTIONS` in `man 2 ptrace`)
 * [ ] Filtering based on string buffer contents
 * [ ] Handling of `exit()` of the direct child (grand-child daemonisation)
 * [ ] Re-using strace's test suite for per-syscall tests
 * [ ] other TODOs in the code
+* Use it to do specific investigations in other programs:
+  * [ ] investigate [big GHC linker speed differences](https://github.com/nh2/hatrace/pull/9#issuecomment-477573945)

--- a/hatrace.cabal
+++ b/hatrace.cabal
@@ -37,6 +37,7 @@ library
                      , conduit
                      , containers
                      , directory
+                     , filepath
                      , linux-ptrace
                      , optparse-applicative
                      , posix-waitpid

--- a/src/System/Hatrace.hs
+++ b/src/System/Hatrace.hs
@@ -1018,17 +1018,16 @@ fileWritesConduit = go
           detailedSyscallExit <- liftIO $ getSyscallExitDetails syscall syscallArgs pid
           case detailedSyscallExit of
             Right (DetailedSyscallExit_open SyscallExitDetails_open
-                   { enterDetail = SyscallEnterDetails_open { pathnameBS, flags }
+                   { enterDetail = SyscallEnterDetails_open { pathnameBS }
                    , fd }) ->
-              when (allowsWrites flags) $ yieldFdEvent pid fd (FileOpen pathnameBS)
+              yieldFdEvent pid fd (FileOpen pathnameBS)
             Right (DetailedSyscallExit_openat SyscallExitDetails_openat
-                   { enterDetail = SyscallEnterDetails_openat { pathnameBS, flags }
+                   { enterDetail = SyscallEnterDetails_openat { pathnameBS }
                    , fd }) ->
-              when (allowsWrites flags) $ yieldFdEvent pid fd (FileOpen pathnameBS)
+              yieldFdEvent pid fd (FileOpen pathnameBS)
             Right (DetailedSyscallExit_creat SyscallExitDetails_creat
                    { enterDetail = SyscallEnterDetails_creat { pathnameBS }
                    , fd }) ->
-              -- creat uses O_WRONLY
               yieldFdEvent pid fd (FileOpen pathnameBS)
             _ -> return ()
           go
@@ -1051,10 +1050,6 @@ fileWritesConduit = go
     yieldFdEvent pid fd event = do
       path <- liftIO $ getFdPath pid fd
       yield (path, event)
-    o_WRONLY = 0o00000001
-    o_RDWR   = 0o00000002
-    allowsWrites flags = flags .&. writeModes /= 0
-    writeModes = o_WRONLY .|. o_RDWR
 
 resolveToPidCwd :: Show a => a -> FilePath -> IO FilePath
 resolveToPidCwd pid path = do

--- a/src/System/Hatrace.hs
+++ b/src/System/Hatrace.hs
@@ -48,6 +48,10 @@ module System.Hatrace
   , getSyscallEnterDetails
   , syscallEnterDetailsOnlyConduit
   , syscallExitDetailsOnlyConduit
+  , FileWriteEvent(..)
+  , fileWritesConduit
+  , FileWriteBehavior(..)
+  , atomicWritesSink
   , SyscallStopType(..)
   , TraceEvent(..)
   , TraceState(..)
@@ -55,21 +59,29 @@ module System.Hatrace
   , SyscallArgs(..)
   , sendSignal
   , doesProcessHaveChildren
+  , getFdPath
   -- * Re-exports
   , KnownSyscall(..)
   ) where
 
+import           Conduit (foldlC)
+import           Control.Arrow (second)
+import           Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
-import           Data.Bits ((.|.), shiftL, shiftR)
+import           Data.Bits ((.|.), (.&.), shiftL, shiftR)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BSI
 import           Data.Conduit
 import qualified Data.Conduit.List as CL
+import           Data.Either (partitionEithers)
 import           Data.List (genericLength)
 import           Data.Map (Map)
 import qualified Data.Map as Map
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import           Data.Word (Word32, Word64)
 import           Foreign.C.Error (Errno(..), throwErrnoIfMinus1, throwErrnoIfMinus1_, getErrno, resetErrno, eCHILD, eINVAL)
 import           Foreign.C.String (peekCString)
@@ -81,8 +93,9 @@ import           Foreign.Marshal.Utils (withMany)
 import           Foreign.Ptr (Ptr, nullPtr, wordPtrToPtr)
 import           Foreign.Storable (peekByteOff, sizeOf)
 import           GHC.Stack (HasCallStack, callStack, getCallStack, prettySrcLoc)
-import           System.Directory (doesFileExist, findExecutable)
+import           System.Directory (canonicalizePath, doesFileExist, findExecutable)
 import           System.Exit (ExitCode(..), die)
+import           System.FilePath ((</>))
 import           System.IO.Error (modifyIOError, ioeGetLocation, ioeSetLocation)
 import           System.Linux.Ptrace (TracedProcess(..), peekBytes, peekNullTerminatedBytes, peekNullWordTerminatedWords, detach)
 import           System.Linux.Ptrace.Syscall hiding (ptrace_syscall, ptrace_detach)
@@ -90,6 +103,7 @@ import qualified System.Linux.Ptrace.Syscall as Ptrace.Syscall
 import           System.Linux.Ptrace.Types (Regs(..))
 import           System.Linux.Ptrace.X86_64Regs (X86_64Regs(..))
 import           System.Linux.Ptrace.X86Regs (X86Regs(..))
+import           System.Posix.Files (readSymbolicLink)
 import           System.Posix.Internals (withFilePath)
 import           System.Posix.Signals (Signal, sigTRAP, sigSTOP, sigTSTP, sigTTIN, sigTTOU)
 import qualified System.Posix.Signals as Signals
@@ -962,6 +976,139 @@ traceForkExecvFullPath args = do
     sourceTraceForkExecvFullPathWithSink args (printSyscallOrSignalNameConduit .| CL.sinkNull)
   return exitCode
 
+
+-- | Like the partial `T.decodeUtf8`, with `HasCallStack`.
+decodeUtf8OrError :: (HasCallStack) => ByteString -> Text
+decodeUtf8OrError bs = case T.decodeUtf8' bs of
+  Left err -> error $ "Could not decode as UTF-8: " ++ show err ++ "; ByteString was : " ++ show bs
+  Right text -> text
+
+
+getFdPath :: CPid -> CInt -> IO FilePath
+getFdPath pid fd = do
+  let procFdPath = "/proc/" ++ show pid ++ "/fd/" ++ show fd
+  readSymbolicLink procFdPath
+
+
+data FileWriteEvent
+  = FileOpen ByteString
+  | FileWrite
+  | FileClose
+  | FileRename ByteString -- ^ new (target) name
+  deriving (Eq, Ord, Show)
+
+-- NOTES:
+-- * the code doesn't register `open` syscalls for files opened as readonly,
+--   at the same time this filter isn't applied for other syscalls (close, rename)
+-- * only calls to `write` are currently used as a marker for writes and syscalls
+--   `pwrite`, `writev`, `pwritev` are not taken into account
+fileWritesConduit :: (MonadIO m) => ConduitT (CPid, TraceEvent) (FilePath, FileWriteEvent) m ()
+fileWritesConduit = go
+  where
+    go =
+      await >>= \case
+        Just (pid, SyscallStop (SyscallExit (KnownSyscall syscall, syscallArgs))) -> do
+          detailedSyscallExit <- liftIO $ getSyscallExitDetails syscall syscallArgs pid
+          case detailedSyscallExit of
+            Right (DetailedSyscallExit_open SyscallExitDetails_open
+                   { enterDetail = SyscallEnterDetails_open { pathnameBS, flags }
+                   , fd }) ->
+              when (allowsWrites flags) $ yieldFdEvent pid fd (FileOpen pathnameBS)
+            Right (DetailedSyscallExit_openat SyscallExitDetails_openat
+                   { enterDetail = SyscallEnterDetails_openat { pathnameBS, flags }
+                   , fd }) ->
+              when (allowsWrites flags) $ yieldFdEvent pid fd (FileOpen pathnameBS)
+            Right (DetailedSyscallExit_creat SyscallExitDetails_creat
+                   { enterDetail = SyscallEnterDetails_creat { pathnameBS }
+                   , fd }) ->
+              -- creat uses O_WRONLY
+              yieldFdEvent pid fd (FileOpen pathnameBS)
+            _ -> return ()
+          go
+        Just (pid, SyscallStop (SyscallEnter (KnownSyscall syscall, syscallArgs))) -> do
+          detailedSyscallEnter <- liftIO $ getSyscallEnterDetails syscall syscallArgs pid
+          case detailedSyscallEnter of
+            DetailedSyscallEnter_write SyscallEnterDetails_write { fd } ->
+              yieldFdEvent pid fd FileWrite
+            DetailedSyscallEnter_close SyscallEnterDetails_close { fd } ->
+              yieldFdEvent pid fd FileClose
+            DetailedSyscallEnter_rename SyscallEnterDetails_rename { oldpathBS, newpathBS } -> do
+              path <- liftIO $ resolveToPidCwd pid (T.unpack $ decodeUtf8OrError oldpathBS)
+              yield (path, FileRename newpathBS)
+            _ -> return ()
+          go
+        Just _ ->
+          go -- ignore other events
+        Nothing ->
+          return ()
+    yieldFdEvent pid fd event = do
+      path <- liftIO $ getFdPath pid fd
+      yield (path, event)
+    o_WRONLY = 0o00000001
+    o_RDWR   = 0o00000002
+    allowsWrites flags = flags .&. writeModes /= 0
+    writeModes = o_WRONLY .|. o_RDWR
+
+resolveToPidCwd :: Show a => a -> FilePath -> IO FilePath
+resolveToPidCwd pid path = do
+  let procFdPath = "/proc/" ++ show pid ++ "/cwd"
+  wd <- liftIO $ readSymbolicLink procFdPath
+  canonicalizePath $ wd </> path
+
+
+data FileWriteBehavior
+  = NoWrites
+  | NonatomicWrite
+  | AtomicWrite FilePath
+  -- ^ path tells temporary file name that was used
+  | Unexpected String
+  deriving (Eq, Ord, Show)
+
+analyzeWrites :: [FileWriteEvent] -> FileWriteBehavior
+analyzeWrites events = checkOpen events
+  where
+    checkOpen [] = NoWrites
+    -- we could see a close syscall for a file opened in readonly mode
+    -- thus we just ignore it
+    checkOpen (FileClose:es) = checkOpen es
+    checkOpen (FileOpen _:es) = checkWrites es
+    checkOpen (e:_) = unexpected "FileOpen" e
+    checkWrites [] = Unexpected $ "FileClose was expected but not seen"
+    checkWrites (FileClose:es) = checkOpen es
+    checkWrites (FileWrite:es) = checkWrites' es
+    checkWrites (e: _) = unexpected "FileClose or FileWrite" e
+    checkWrites' [] = Unexpected $ "FileClose was expected but not seen"
+    checkWrites' (FileWrite:es) = checkWrites' es
+    checkWrites' (FileClose:es) = checkRename es
+    checkWrites' (e: _) = unexpected "FileClose or FileWrite" e
+    checkRename (FileRename path:es) =
+      case checkOpen es of
+        NoWrites ->
+          -- we write original path here which swapped
+          -- with oldpath in `atomicWritesSink`
+          AtomicWrite (T.unpack $ decodeUtf8OrError path)
+        other ->
+          other
+    checkRename es =
+      case checkOpen es of
+        NoWrites -> NonatomicWrite
+        other -> other
+    unexpected expected real =
+      Unexpected $ "expected " ++ expected ++ ", but " ++
+                   show real ++ " was seen"
+
+atomicWritesSink :: (MonadIO m) => ConduitT (CPid, TraceEvent) Void m (Map FilePath FileWriteBehavior)
+atomicWritesSink =
+  extract <$> (fileWritesConduit .| foldlC collectWrite mempty)
+  where
+    collectWrite m (fp, e) = Map.alter (Just . maybe [e] (e:)) fp m
+    extract m =
+      let (noRenames, renames) =
+            partitionEithers . map (analyzeWrites' . second reverse) $ Map.toList m
+      in Map.fromList noRenames <> Map.fromList (map (second AtomicWrite) renames)
+    analyzeWrites' (src, es) = case analyzeWrites es of
+      AtomicWrite target -> Right (target, src)
+      other -> Left (src, other)
 
 -- | Passes through all syscalls and signals that come by,
 -- printing them, including details where available.

--- a/src/System/Hatrace.hs
+++ b/src/System/Hatrace.hs
@@ -63,7 +63,8 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
 import           Data.Bits ((.|.), shiftL, shiftR)
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Internal as BS
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BSI
 import           Data.Conduit
 import qualified Data.Conduit.List as CL
 import           Data.List (genericLength)
@@ -773,7 +774,7 @@ readPipeFds pid pipefd = do
   let fdSize = sizeOf (undefined :: CInt)
       sz = 2 * fdSize
   bytes <- peekBytes (TracedProcess pid) pipefd sz
-  let (ptr, off, _size) = BS.toForeignPtr bytes
+  let (ptr, off, _size) = BSI.toForeignPtr bytes
   withForeignPtr ptr $ \p -> do
     (,) <$> peekByteOff p off <*> peekByteOff p (off + fdSize)
 

--- a/src/System/Hatrace.hs
+++ b/src/System/Hatrace.hs
@@ -60,6 +60,7 @@ module System.Hatrace
   , sendSignal
   , doesProcessHaveChildren
   , getFdPath
+  , getExePath
   -- * Re-exports
   , KnownSyscall(..)
   ) where
@@ -988,6 +989,12 @@ getFdPath :: CPid -> CInt -> IO FilePath
 getFdPath pid fd = do
   let procFdPath = "/proc/" ++ show pid ++ "/fd/" ++ show fd
   readSymbolicLink procFdPath
+
+
+getExePath :: CPid -> IO FilePath
+getExePath pid = do
+  let procExePath = "/proc/" ++ show pid ++ "/exe"
+  readSymbolicLink procExePath
 
 
 data FileWriteEvent

--- a/src/System/Hatrace.hs
+++ b/src/System/Hatrace.hs
@@ -67,12 +67,10 @@ module System.Hatrace
 
 import           Conduit (foldlC)
 import           Control.Arrow (second)
-import           Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
-import           Data.Bits ((.|.), (.&.), shiftL, shiftR)
+import           Data.Bits ((.|.), shiftL, shiftR)
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BSI
 import           Data.Conduit
 import qualified Data.Conduit.List as CL
@@ -998,15 +996,16 @@ getExePath pid = do
 
 
 data FileWriteEvent
-  = FileOpen ByteString
+  = FileOpen ByteString -- ^ name used to open the file
   | FileWrite
   | FileClose
   | FileRename ByteString -- ^ new (target) name
   deriving (Eq, Ord, Show)
 
+-- | Uses raw trace events to produce more focused events aimed at analysing file writes.
+-- Output events are accompanied by corresponding absolute file paths.
+--
 -- NOTES:
--- * the code doesn't register `open` syscalls for files opened as readonly,
---   at the same time this filter isn't applied for other syscalls (close, rename)
 -- * only calls to `write` are currently used as a marker for writes and syscalls
 --   `pwrite`, `writev`, `pwritev` are not taken into account
 fileWritesConduit :: (MonadIO m) => ConduitT (CPid, TraceEvent) (FilePath, FileWriteEvent) m ()
@@ -1066,48 +1065,67 @@ data FileWriteBehavior
   | Unexpected String
   deriving (Eq, Ord, Show)
 
+-- uses state machine implemented as recursive functions
 analyzeWrites :: [FileWriteEvent] -> FileWriteBehavior
-analyzeWrites events = checkOpen events
+analyzeWrites es = checkOpen es
   where
-    checkOpen [] = NoWrites
-    -- we could see a close syscall for a file opened in readonly mode
-    -- thus we just ignore it
-    checkOpen (FileClose:es) = checkOpen es
-    checkOpen (FileOpen _:es) = checkWrites es
-    checkOpen (e:_) = unexpected "FileOpen" e
-    checkWrites [] = Unexpected $ "FileClose was expected but not seen"
-    checkWrites (FileClose:es) = checkOpen es
-    checkWrites (FileWrite:es) = checkWrites' es
-    checkWrites (e: _) = unexpected "FileClose or FileWrite" e
-    checkWrites' [] = Unexpected $ "FileClose was expected but not seen"
-    checkWrites' (FileWrite:es) = checkWrites' es
-    checkWrites' (FileClose:es) = checkRename es
-    checkWrites' (e: _) = unexpected "FileClose or FileWrite" e
-    checkRename (FileRename path:es) =
-      case checkOpen es of
-        NoWrites ->
-          -- we write original path here which swapped
-          -- with oldpath in `atomicWritesSink`
-          AtomicWrite (T.unpack $ decodeUtf8OrError path)
-        other ->
-          other
-    checkRename es =
-      case checkOpen es of
-        NoWrites -> NonatomicWrite
-        other -> other
-    unexpected expected real =
+    checkOpen events =
+      case events of
+        [] -> NoWrites
+        -- we could see a `close` syscall for a pipe descriptor
+        -- with no `open` for it thus we just ignore it
+        FileClose : rest -> checkOpen rest
+        FileOpen _ : rest -> checkWrites rest
+        unexpected : _ -> unexpectedEvent "FileOpen" unexpected
+    checkWrites events =
+      case events of
+        [] -> Unexpected $ "FileClose was expected but not seen"
+        FileClose : rest -> checkOpen rest
+        FileWrite : rest -> checkAfterWrite rest
+        unexpected : _ -> unexpectedEvent "FileClose or FileWrite" unexpected
+    checkAfterWrite events =
+      case events of
+        [] -> Unexpected $ "FileClose was expected but not seen"
+        FileWrite : rest -> checkAfterWrite rest
+        FileClose : rest -> checkRename rest
+        unexpected : _ -> unexpectedEvent "FileClose or FileWrite" unexpected
+    -- when it happens that a path gets more than 1 sequence open-write-close
+    -- for it we need to check whether there was a `rename` after the 1st one
+    -- and then check the result of the next one and combine them accordingly
+    -- e.g. atomic + non-atomic -> non-atomic
+    checkRename events =
+      case events of
+        FileRename path : rest ->
+          case checkOpen rest of
+            NoWrites ->
+              -- we write original path here which swapped
+              -- with oldpath in `atomicWritesSink`
+              AtomicWrite (T.unpack $ decodeUtf8OrError path)
+            other ->
+              other
+        noRenames ->
+          case checkOpen noRenames of
+            NoWrites -> NonatomicWrite
+            other -> other
+    unexpectedEvent expected real =
       Unexpected $ "expected " ++ expected ++ ", but " ++
                    show real ++ " was seen"
 
 atomicWritesSink :: (MonadIO m) => ConduitT (CPid, TraceEvent) Void m (Map FilePath FileWriteBehavior)
 atomicWritesSink =
-  extract <$> (fileWritesConduit .| foldlC collectWrite mempty)
+  extract <$> (fileWritesConduit .| foldlC collectWrite Map.empty)
   where
+    collectWrite :: Map FilePath [FileWriteEvent] -> (FilePath, FileWriteEvent) -> Map FilePath [FileWriteEvent]
     collectWrite m (fp, e) = Map.alter (Just . maybe [e] (e:)) fp m
+    extract :: Map FilePath [FileWriteEvent] -> Map FilePath FileWriteBehavior
     extract m =
       let (noRenames, renames) =
             partitionEithers . map (analyzeWrites' . second reverse) $ Map.toList m
       in Map.fromList noRenames <> Map.fromList (map (second AtomicWrite) renames)
+    -- this function (in addition to what `analyzeWrites` does) treats atomic writes
+    -- in a special way: those include a rename and we need to put atomic writes under
+    -- a path which is a target of a corresponding rename
+    -- so in the end we swap path in `AtomicWrite` and its corresponding map key
     analyzeWrites' (src, es) = case analyzeWrites es of
       AtomicWrite target -> Right (target, src)
       other -> Left (src, other)

--- a/test/HatraceSpec.hs
+++ b/test/HatraceSpec.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString as BS
 import           Data.Conduit
 import qualified Data.Conduit.Combinators as CC
 import qualified Data.Conduit.List as CL
+import qualified Data.Map as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -343,6 +344,27 @@ spec = before_ assertNoChildren $ do
 
     it "can be used to check whether programs handle EINTR correctly" $ do
       pendingWith "implement test that uses PTRACE_INTERRUPT in every syscall"
+
+    it "observes atomic write in a program" $ do
+        makeAtomicWriteExample
+        tmpFile <- emptySystemTempFile "test-output"
+        argv <- procToArgv "example-programs-build/atomic-write" ["atomic", "10", tmpFile]
+        (exitCode, writes) <-
+          sourceTraceForkExecvFullPathWithSink argv atomicWritesSink
+        exitCode `shouldBe` ExitSuccess
+        case Map.lookup tmpFile writes of
+          Just (AtomicWrite _) -> return ()
+          other -> error $ "atomic write for " ++ show tmpFile ++
+                           " was expected but found " ++ show other
+
+    it "catches non-atomic write in a program" $ do
+        makeAtomicWriteExample
+        tmpFile <- emptySystemTempFile "test-output"
+        argv <- procToArgv "example-programs-build/atomic-write" ["non-atomic", "10", tmpFile]
+        (exitCode, writes) <-
+          sourceTraceForkExecvFullPathWithSink argv atomicWritesSink
+        exitCode `shouldBe` ExitSuccess
+        Map.lookup tmpFile writes `shouldBe` Just NonatomicWrite
 
   describe "per-syscall tests" $ do
 

--- a/test/HatraceSpec.hs
+++ b/test/HatraceSpec.hs
@@ -236,6 +236,7 @@ spec = before_ assertNoChildren $ do
       -- directly from the terminal, or want to give your own GHC (see below).
       let program = "env"
       let ghc = "ghc"
+      -- For my fixed GHC
       -- let ghc = "/raid/src/ghc/ghc-atomic-writes/_build/stage1/bin/ghc"
       -- So that a custom path can be given conveniently when testing a patch.
       -- You probably want to set GHC_PACKAGE_PATH below when doing that so that
@@ -243,6 +244,9 @@ spec = before_ assertNoChildren $ do
       let isPatchedGhc = ghc /= "ghc"
       let args =
             [ ghc
+            -- For my fixed GHC
+            -- Note it's very important that GHC_PACKAGE_PATH does not end with a '/',
+            -- see https://gitlab.haskell.org/ghc/ghc/issues/16360
             -- [ "GHC_PACKAGE_PATH=/raid/src/ghc/ghc-atomic-writes/_build/stage1/lib/package.conf.d", ghc
             , "--make"
             , "-outputdir", "example-programs-build/"


### PR DESCRIPTION
`stack run -- hatrace --find-nonatomic-writes stack test` on `hatrace` itself ended up with

<details>
  <summary>test failure and many nonatomically written files</summary>

```
hatrace-0.1.0.0: Test suite hatrace-test failed
Completed 2 action(s).
Test suite failure for package hatrace-0.1.0.0
    hatrace-test:  exited with: ExitFailure 1
Logs printed to console

The following files were written nonatomically by the program:
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace.dyn_hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace.dyn_o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/Main.dyn_hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/Main.dyn_o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/Main.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/Main.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables.dyn_hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables.dyn_o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Generated.dyn_hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Generated.dyn_o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Generated.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Generated.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Util.dyn_hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Util.dyn_o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Util.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/System/Hatrace/SyscallTables/Util.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace-test/hatrace-test-tmp/HatraceSpec.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace-test/hatrace-test-tmp/HatraceSpec.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace-test/hatrace-test-tmp/Main.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace-test/hatrace-test-tmp/Main.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace-test/hatrace-test-tmp/test/HatraceSpec.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace-test/hatrace-test-tmp/test/Spec.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace/hatrace-tmp/Main.hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace/hatrace-tmp/Main.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/hatrace/hatrace-tmp/app/Main.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/objs-29366/ar29366-2.rsp"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/src/System/Hatrace.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/src/System/Hatrace/Main.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/src/System/Hatrace/SyscallTables.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/src/System/Hatrace/SyscallTables/Generated.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/src/System/Hatrace/SyscallTables/Util.dump-hi"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/stack-build-caches/exe-hatrace"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/stack-build-caches/lib"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/stack-build-caches/test-hatrace-test"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/stack-cabal-mod"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/stack-config-cache"
 - "/home/qrilka/ws/h/hatrace/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/stack-test-success"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/flag-cache/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/lib/x86_64-linux-ghc-8.6.3/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y/st4CzNEy/Generated.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/lib/x86_64-linux-ghc-8.6.3/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y/st4CzNEy/Hatrace.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/lib/x86_64-linux-ghc-8.6.3/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y/st4CzNEy/Main.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/lib/x86_64-linux-ghc-8.6.3/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y/st4CzNEy/SyscallTables.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/lib/x86_64-linux-ghc-8.6.3/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y/st4CzNEy/Util.o"
 - "/home/qrilka/ws/h/hatrace/.stack-work/install/x86_64-linux-tinfo6/lts-13.6/8.6.3/lib/x86_64-linux-ghc-8.6.3/hatrace-0.1.0.0-4Xc0nbwTGqM4mpFStsQs5y/st4CzNEy/fork-exec-ptrace.o"
 - "/home/qrilka/ws/h/hatrace/example-programs-build/Main.hi"
 - "/home/qrilka/ws/h/hatrace/example-programs-build/Main.o"
 - "/tmp/29304-0.c"
 - "/tmp/29304-1.o"
 - "/tmp/29304-4.c"
 - "/tmp/cc2jQlJ7"
 - "/tmp/cc48PIsb"
 - "/tmp/cc4gt17L.s"
 - "/tmp/cc6TeU9f"
 - "/tmp/ccCJcdSa"
 - "/tmp/ccCSqQzu.o"
 - "/tmp/ccHyCbfl"
 - "/tmp/ccI1l0ew"
 - "/tmp/ccOXjJYb"
 - "/tmp/ccUsWEzQ.s"
 - "/tmp/ccY0JCSc.s"
 - "/tmp/ccp9JTmj"
 - "/tmp/cctzY1tC"
 - "/tmp/ccuEA9Fg"
 - "/tmp/ccz5kOyU.s"
 - "/tmp/ghc29346_0/ghc_1.s"
 - "/tmp/ghc29346_0/ghc_2.rsp"
 - "/tmp/ghc29372_0/ghc_1.hscpp"
 - "/tmp/ghc29372_0/ghc_11.s"
 - "/tmp/ghc29372_0/ghc_14.rsp"
 - "/tmp/ghc29372_0/ghc_16.s"
 - "/tmp/ghc29372_0/ghc_18.s"
 - "/tmp/ghc29372_0/ghc_2.h"
 - "/tmp/ghc29372_0/ghc_21.s"
 - "/tmp/ghc29372_0/ghc_23.s"
 - "/tmp/ghc29372_0/ghc_26.s"
 - "/tmp/ghc29372_0/ghc_28.s"
 - "/tmp/ghc29372_0/ghc_4.s"
 - "/tmp/ghc29372_0/ghc_6.s"
 - "/tmp/ghc29372_0/ghc_9.s"
 - "/tmp/ghc29521_0/ghc_1.rsp"
 - "/tmp/ghc29540_0/ghc_2.s"
 - "/tmp/ghc29555_0/ghc_1.c"
 - "/tmp/ghc29555_0/ghc_2.o"
 - "/tmp/ghc29555_0/ghc_3.rsp"
 - "/tmp/ghc29555_0/ghc_4.s"
 - "/tmp/ghc29555_0/ghc_5.o"
 - "/tmp/ghc29555_0/ghc_6.rsp"
 - "/tmp/ghc29555_0/ghc_7.rsp"
 - "/tmp/ghc29587_0/ghc_1.hspp"
 - "/tmp/ghc29587_0/ghc_3.s"
 - "/tmp/ghc29587_0/ghc_6.s"
 - "/tmp/ghc29612_0/ghc_1.hspp"
 - "/tmp/ghc29612_0/ghc_2.c"
 - "/tmp/ghc29612_0/ghc_3.o"
 - "/tmp/ghc29612_0/ghc_4.rsp"
 - "/tmp/ghc29612_0/ghc_5.s"
 - "/tmp/ghc29612_0/ghc_6.o"
 - "/tmp/ghc29612_0/ghc_7.rsp"
 - "/tmp/ghc29612_0/ghc_8.rsp"
 - "/tmp/ghc29876_0/ghc_10.rsp"
 - "/tmp/ghc29876_0/ghc_2.s"
 - "/tmp/ghc29876_0/ghc_4.c"
 - "/tmp/ghc29876_0/ghc_5.o"
 - "/tmp/ghc29876_0/ghc_6.rsp"
 - "/tmp/ghc29876_0/ghc_7.s"
 - "/tmp/ghc29876_0/ghc_8.o"
 - "/tmp/ghc29876_0/ghc_9.rsp"
The following files could not be properly analyzed:
 - "/tmp/ccCmHopn.ld": expected FileOpen, but FileWrite was seen
 - "/tmp/ccEVe04g.ld": expected FileOpen, but FileWrite was seen
 - "/tmp/ccJVK5fG.ld": expected FileOpen, but FileWrite was seen
 - "/tmp/ccRb8LBd.ld": expected FileOpen, but FileWrite was seen
 - "/tmp/ccut9yzR.ld": expected FileOpen, but FileWrite was seen
```
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nh2/hatrace/9)
<!-- Reviewable:end -->
