### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
+EXAMPLE_SRC := example-programs
+EXAMPLE_DST := example-programs-build
+
 EXAMPLE_PROGRAMS :=
-EXAMPLE_PROGRAMS += example-programs-build/hello-linux-i386
-EXAMPLE_PROGRAMS += example-programs-build/hello-linux-i386-elf64
-EXAMPLE_PROGRAMS += example-programs-build/hello-linux-x86_64
-EXAMPLE_PROGRAMS += example-programs-build/segfault
-EXAMPLE_PROGRAMS += example-programs-build/execve
-EXAMPLE_PROGRAMS += example-programs-build/execve-linux-null-envp
-EXAMPLE_PROGRAMS += example-programs-build/atomic-write
-EXAMPLE_PROGRAMS += example-programs-build/write-EBADF
-EXAMPLE_PROGRAMS += example-programs-build/access-itself
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/hello-linux-i386
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/hello-linux-i386-elf64
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/hello-linux-x86_64
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/segfault
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/execve
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/execve-linux-null-envp
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/atomic-write
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/write-EBADF
+EXAMPLE_PROGRAMS += $(EXAMPLE_DST)/access-itself
 
 .PHONY: example-programs
 example-programs: $(EXAMPLE_PROGRAMS)
@@ -16,30 +19,30 @@ example-programs: $(EXAMPLE_PROGRAMS)
 # syscalls related to dynamic loading, thus avoiding a syscall flood
 # unrelated to the key thing each program does.
 
-example-programs-build/%-i386: example-programs/%-i386.asm
-	mkdir -p example-programs-build
+$(EXAMPLE_DST)/%-i386: $(EXAMPLE_SRC)/%-i386.asm
+	mkdir -p $(EXAMPLE_DST)
 	nasm -Wall -Werror -f elf $< -o $@.o
 	ld -m elf_i386 -e _start $@.o -o $@
 	rm $@.o
 
-example-programs-build/%-i386-elf64: example-programs/%-i386.asm
-	mkdir -p example-programs-build
+$(EXAMPLE_DST)/%-i386-elf64: $(EXAMPLE_SRC)/%-i386.asm
+	mkdir -p $(EXAMPLE_DST)
 	nasm -Wall -Werror -f elf64 $< -o $@.o
 	ld -e _start $@.o -o $@
 	rm $@.o
 
-example-programs-build/%-x86_64: example-programs/%-x86_64.asm
-	mkdir -p example-programs-build
+$(EXAMPLE_DST)/%-x86_64: $(EXAMPLE_SRC)/%-x86_64.asm
+	mkdir -p $(EXAMPLE_DST)
 	nasm -Wall -Werror -f elf64 $< -o $@.o
 	ld -e _start $@.o -o $@
 	rm $@.o
 
-example-programs-build/%: example-programs/%.asm
-	mkdir -p example-programs-build
+$(EXAMPLE_DST)/%: $(EXAMPLE_SRC)/%.asm
+	mkdir -p $(EXAMPLE_DST)
 	nasm -Wall -Werror -f elf64 $< -o $@.o
 	ld -e _start $@.o -o $@
 	rm $@.o
 
-example-programs-build/%: example-programs/%.c
-	mkdir -p example-programs-build
+$(EXAMPLE_DST)/%: $(EXAMPLE_SRC)/%.c
+	mkdir -p $(EXAMPLE_DST)
 	gcc -static -std=c99 -Wall -Werror $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -16,46 +16,30 @@ example-programs: $(EXAMPLE_PROGRAMS)
 # syscalls related to dynamic loading, thus avoiding a syscall flood
 # unrelated to the key thing each program does.
 
-example-programs-build/hello-linux-i386: example-programs/hello-linux-i386.asm
+example-programs-build/%-i386: example-programs/%-i386.asm
 	mkdir -p example-programs-build
-	nasm -Wall -Werror -f elf example-programs/hello-linux-i386.asm -o example-programs-build/hello-linux-i386.o
-	ld -m elf_i386 -e _start example-programs-build/hello-linux-i386.o -o example-programs-build/hello-linux-i386
-	rm example-programs-build/hello-linux-i386.o
+	nasm -Wall -Werror -f elf $< -o $@.o
+	ld -m elf_i386 -e _start $@.o -o $@
+	rm $@.o
 
-example-programs-build/hello-linux-i386-elf64: example-programs/hello-linux-i386.asm
+example-programs-build/%-i386-elf64: example-programs/%-i386.asm
 	mkdir -p example-programs-build
-	nasm -Wall -Werror -f elf64 example-programs/hello-linux-i386.asm -o example-programs-build/hello-linux-i386-elf64.o
-	ld -e _start example-programs-build/hello-linux-i386-elf64.o -o example-programs-build/hello-linux-i386-elf64
-	rm example-programs-build/hello-linux-i386-elf64.o
+	nasm -Wall -Werror -f elf64 $< -o $@.o
+	ld -e _start $@.o -o $@
+	rm $@.o
 
-example-programs-build/hello-linux-x86_64: example-programs/hello-linux-x86_64.asm
+example-programs-build/%-x86_64: example-programs/%-x86_64.asm
 	mkdir -p example-programs-build
-	nasm -Wall -Werror -f elf64 example-programs/hello-linux-x86_64.asm -o example-programs-build/hello-linux-x86_64.o
-	ld -e _start example-programs-build/hello-linux-x86_64.o -o example-programs-build/hello-linux-x86_64
-	rm example-programs-build/hello-linux-x86_64.o
+	nasm -Wall -Werror -f elf64 $< -o $@.o
+	ld -e _start $@.o -o $@
+	rm $@.o
 
-example-programs-build/segfault: example-programs/segfault.asm
+example-programs-build/%: example-programs/%.asm
 	mkdir -p example-programs-build
-	nasm -Wall -Werror -f elf64 example-programs/segfault.asm -o example-programs-build/segfault.o
-	ld -e _start example-programs-build/segfault.o -o example-programs-build/segfault
-	rm example-programs-build/segfault.o
+	nasm -Wall -Werror -f elf64 $< -o $@.o
+	ld -e _start $@.o -o $@
+	rm $@.o
 
-example-programs-build/execve: example-programs/execve.c
+example-programs-build/%: example-programs/%.c
 	mkdir -p example-programs-build
-	gcc -static -std=c99 -Wall -Werror example-programs/execve.c -o example-programs-build/execve
-
-example-programs-build/execve-linux-null-envp: example-programs/execve-linux-null-envp.c
-	mkdir -p example-programs-build
-	gcc -static -std=c99 -Wall -Werror example-programs/execve-linux-null-envp.c -o example-programs-build/execve-linux-null-envp
-
-example-programs-build/atomic-write: example-programs/atomic-write.c
-	mkdir -p example-programs-build
-	gcc -static -std=c99 -Wall -Werror example-programs/atomic-write.c -o example-programs-build/atomic-write
-
-example-programs-build/write-EBADF: example-programs/write-EBADF.c
-	mkdir -p example-programs-build
-	gcc -static -std=c99 -Wall -Werror example-programs/write-EBADF.c -o example-programs-build/write-EBADF
-
-example-programs-build/access-itself: example-programs/access-itself.c
-	mkdir -p example-programs-build
-	gcc -static -std=c99 -Wall -Werror example-programs/access-itself.c -o example-programs-build/access-itself
+	gcc -static -std=c99 -Wall -Werror $< -o $@


### PR DESCRIPTION
This replaces the copy-pasted directory names with variables, and introduces generic targets to build all the existing example programs, so that new tests don't need to copy rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nh2/hatrace/28)
<!-- Reviewable:end -->
