### PR TITLE
 Support brk syscall

### DIFF
--- a/example-programs/brk-syscall.c
+++ b/example-programs/brk-syscall.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <stdio.h>
+#include <assert.h>
+
+int main(int argc, char *argv[])
+{
+    int *init_program_break = (int *) syscall(SYS_brk, 0x0);
+    int *greater_program_break = (int *) syscall(SYS_brk, init_program_break + 0x100);
+    int *restored_program_break = (int *) syscall(SYS_brk, greater_program_break - 0x100);
+    assert(init_program_break == restored_program_break);
+    return 0;
+}
+


### PR DESCRIPTION
Add strace-like support for brk syscall. An example program used in tests can be found in example-programs/brk-syscall.c.

See description of brk in http://man7.org/linux/man-pages/man2/brk.2.html and mind the note about the **actual return value** of the Linux system call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nh2/hatrace/32)
<!-- Reviewable:end -->
