### PR TITLE
circleci: Try `-small` docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,14 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts
+      # Note: The `lts` tag changes over time and thus isn't reproducible.
+      - image: fpco/stack-build-small:lts
     steps:
       - checkout
       - run: git submodule sync && git submodule update --init
       - run:
           name: Install system dependencies
-          command: sudo apt-get update && sudo apt-get install -y nasm
+          command: apt-get update && apt-get install -y nasm
       - restore_cache:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           name: Restore Cached Dependencies


### PR DESCRIPTION
It's 10x smaller (330 MB vs 3 GB), thus hopefully reducing CircleCI's current
94 seconds on the `Spin up Environment` step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nh2/hatrace/44)
<!-- Reviewable:end -->
