### PR TITLE
Add cabal.project to allow building with cabal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,7 @@
 packages: .
 
+# Keep deps in sync with `stack.yaml`.
+
 source-repository-package
     type: git
     location: https://github.com/nh2/linux-ptrace

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,11 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/nh2/linux-ptrace
+    tag: 8969355c2e1ce095ef58acc5f2c5f8a4ea3f1645
+
+source-repository-package
+    type: git
+    location: https://github.com/nh2/posix-waitpid.git
+    tag: d2d7e06d85965dd022705d3d4e8348940afabb5f

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@
 resolver: lts-13.6
 packages:
 - .
+# Keep deps in sync with `cabal.project`.
 extra-deps:
 - git: https://github.com/nh2/linux-ptrace
   commit: 8969355c2e1ce095ef58acc5f2c5f8a4ea3f1645


### PR DESCRIPTION
The posix-waitpid and linux-ptrace dependendencies on Hackage are quite
outdated which is why `stack.yaml` has them as git dependencies instead.

When trying to build with cabal we just get a bunch of solver errors. So I
fix this by adding the cabal equivalent of stack.yaml, cabal.project, with
the git dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nh2/hatrace/64)
<!-- Reviewable:end -->
